### PR TITLE
Add session management endpoints1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Zero‑Knowledge File Exchange Gateway (ZK‑FEG)
+# Zero-Knowledge File Exchange Gateway (ZK-FEG)
 
-A FastAPI service providing secure file exchange with zero‑knowledge integrity proofs.
+A FastAPI service providing secure file exchange with zero-knowledge integrity proofs.
 
 ## Features
-- Create file‑exchange sessions
+- Create file-exchange sessions
 - Upload encrypted file chunks
-- Submit Merkle‑root + ZK proof
+- Submit Merkle-root + ZK proof
 - Download metadata and encrypted chunks
+- List and delete sessions
 - Health check endpoint
 
 ## Requirements
@@ -20,9 +21,10 @@ git clone <repo_url>
 cd zk_feg_api_repo
 
 # Create virtual env & install
-env/bin/python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 
 # Run locally
-env/bin/python -m uvicorn app.main:app --reload
+uvicorn app.main:app --reload
+```

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -4,6 +4,11 @@ from .. import crud, models
 
 router = APIRouter(prefix="/v1/sessions", tags=["sessions"])
 
+@router.get("/", response_model=models.SessionListResponse)
+def list_sessions():
+    sessions = crud.list_sessions()
+    return {"sessions": sessions}
+
 @router.post("/", response_model=models.SessionCreateResponse)
 def create_session(req: models.SessionCreateRequest):
     sid = crud.create_session(req.filename, req.metadata)
@@ -48,3 +53,11 @@ def get_chunk(session_id: str, index: int):
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Chunk not found")
     return StreamingResponse(iter([chunk]), media_type="application/octet-stream")
+
+@router.delete("/{session_id}", response_model=models.SessionDeleteResponse)
+def delete_session(session_id: str):
+    try:
+        crud.delete_session(session_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"success": True}

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shutil
 from .core.config import settings
 from .local import LocalZKFileExchange
 
@@ -7,6 +8,15 @@ _engine = LocalZKFileExchange(settings.STORAGE_DIR)
 
 def create_session(filename: str, metadata: dict) -> str:
     return _engine.create_session(filename, metadata)
+
+def list_sessions() -> list[str]:
+    if not os.path.isdir(settings.STORAGE_DIR):
+        return []
+    return [
+        name
+        for name in os.listdir(settings.STORAGE_DIR)
+        if os.path.isdir(os.path.join(settings.STORAGE_DIR, name))
+    ]
 
 def upload_chunk(session_id: str, index: int, ciphertext: bytes, nonce: bytes, tag: bytes):
     path = os.path.join(settings.STORAGE_DIR, session_id)
@@ -30,3 +40,9 @@ def get_metadata(session_id: str) -> dict:
 def get_chunk(session_id: str, index: int) -> bytes:
     path = os.path.join(settings.STORAGE_DIR, session_id, f"chunk_{index:05d}.bin")
     return open(path, "rb").read()
+
+def delete_session(session_id: str):
+    path = os.path.join(settings.STORAGE_DIR, session_id)
+    if not os.path.isdir(path):
+        raise FileNotFoundError
+    shutil.rmtree(path)

--- a/app/models.py
+++ b/app/models.py
@@ -22,3 +22,9 @@ class MetadataResponse(BaseModel):
     merkle_root: str
     zk_proof: str
     chunk_count: int
+
+class SessionListResponse(BaseModel):
+    sessions: list[str]
+
+class SessionDeleteResponse(BaseModel):
+    success: bool

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import shutil
+sys.path.insert(0, os.path.abspath("."))
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def setup_module(module):
+    os.environ['STORAGE_DIR'] = './test_storage'
+    if os.path.isdir('./test_storage'):
+        shutil.rmtree('./test_storage')
+    os.makedirs('./test_storage')
+
+
+def teardown_module(module):
+    if os.path.isdir('./test_storage'):
+        shutil.rmtree('./test_storage')
+
+
+client = TestClient(app)
+
+def test_session_lifecycle():
+    # create session
+    resp = client.post('/v1/sessions/', json={'filename': 'foo.txt', 'metadata': {}})
+    assert resp.status_code == 200
+    sid = resp.json()['session_id']
+
+    # list sessions should contain new id
+    resp = client.get('/v1/sessions/')
+    assert resp.status_code == 200
+    assert sid in resp.json()['sessions']
+
+    # delete session
+    resp = client.delete(f'/v1/sessions/{sid}')
+    assert resp.status_code == 200
+
+    # list sessions should not contain id
+    resp = client.get('/v1/sessions/')
+    assert sid not in resp.json()['sessions']
+


### PR DESCRIPTION
## Summary
- clean up README
- add CRUD functions for listing and deleting sessions
- expose new API routes for listing and deleting sessions
- add models for new endpoints
- test full session lifecycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cff4f8bac83258426904d3c4adb01